### PR TITLE
Copy IDs bundle

### DIFF
--- a/contributed/CopyIDs.spBundle/command.plist
+++ b/contributed/CopyIDs.spBundle/command.plist
@@ -19,7 +19,9 @@
 		print id
 	}
 }' | __CF_USER_TEXT_ENCODING=$UID:0x8000100:0x8000100 pbcopy
-growlnotify -m "IDs copied to clipboard"</string>
+if [ -x /usr/local/bin/growlnotify ]; then
+    growlnotify -m "IDs copied to clipboard"
+fi</string>
 	<key>contact</key>
 	<string>zngg@uhyynonybb.pb.hx</string>
 	<key>description</key>


### PR DESCRIPTION
Hi

I've added a bundle I wrote that copies the first field (e.g. ID) of each selected row.

It's useful for then writing a query to act on a linked table, or similar

e.g. UPDATE name WHERE id IN [1,2,3]

Thought other might find it useful.

Kind regards,

Matt
