### PR TITLE
Table Switcher Bundle

### DIFF
--- a/contributed/Table-Switcher.spBundle/command.plist
+++ b/contributed/Table-Switcher.spBundle/command.plist
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Nick Tyler</string>
+	<key>command</key>
+	<string># check for empty STDIN
+SEARCHED_TABLE=$(cat)
+if [ -z "$SEARCHED_TABLE" ]; then
+	exit
+fi
+
+# Store all tables in array
+OIFS=$IFS;
+IFS='\t' read -a array &lt;&lt;&lt; "$string"
+
+TABLE_ARRAY=($SP_ALL_TABLES);
+
+IFS=$OIFS
+
+# Searches an array for a string
+containsElement () {
+  local e
+  for e in "${@:2}"; do [[ "$e" == *"$1"* ]] &amp;&amp; echo $e; done
+}
+
+MATCHED_TABLES=($(containsElement "$SEARCHED_TABLE" "${TABLE_ARRAY[@]}"))
+
+# See if one table matches the given string, select it if so
+if [ ${#MATCHED_TABLES[@]} -eq 0 ]; then
+  exit
+else
+  open sequelpro://$SP_PROCESS_ID@passToDoc/SelectTable/${MATCHED_TABLES[0]}
+fi
+
+</string>
+	<key>contact</key>
+	<string>avpx@tbthneqvna.pbz</string>
+	<key>description</key>
+	<string>Enter a table name or a part of a table name, and this bundle will select the first matching table in the current database.</string>
+	<key>input</key>
+	<string>entirecontent</string>
+	<key>input_fallback</key>
+	<string>entirecontent</string>
+	<key>internalKeyEquivalent</key>
+	<dict>
+		<key>characters</key>
+		<string>
+</string>
+		<key>keyCode</key>
+		<integer>36</integer>
+		<key>modifierFlags</key>
+		<integer>1048576</integer>
+	</dict>
+	<key>keyEquivalent</key>
+	<string>@
+</string>
+	<key>name</key>
+	<string>Table Switcher</string>
+	<key>output</key>
+	<string>replacecontent</string>
+	<key>scope</key>
+	<string>inputfield</string>
+	<key>tooltip</key>
+	<string>Switches to the currently filtered table, if one exists.</string>
+	<key>uuid</key>
+	<string>AA3566E7-96E4-4576-8D8C-E465A17264E9</string>
+</dict>
+</plist>


### PR DESCRIPTION
  - This bundle selects a table in the currently connected database, based on the input provided in STDIN. If the provided string matches any database tables, selects the first one. Used in conjunction with the "filter tables" command provided in Sequel Pro to easily switch to a typed-in table.