### PR TITLE
Format a selected UNIX timestamp as ISO 8601 and show it in a tooltip

### DIFF
--- a/contributed/Format UNIX timestamp.spBundle/command.plist
+++ b/contributed/Format UNIX timestamp.spBundle/command.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Niklas Brunberg</string>
+	<key>category</key>
+	<string></string>
+	<key>command</key>
+	<string>#!/usr/bin/php
+&lt;?php
+
+// Suppress DateTime warnings because UNIX timestamps does not contain any
+// timezone information, therefore it would be best to assume some default.
+date_default_timezone_set(@date_default_timezone_get());
+
+print date(DATE_ISO8601, fgets(STDIN));</string>
+	<key>contact</key>
+	<string>niklas@lynks.se</string>
+	<key>description</key>
+	<string>Format the selected UNIX timestamp as ISO 8601</string>
+	<key>input</key>
+	<string>entirecontent</string>
+	<key>internalKeyEquivalent</key>
+	<dict>
+		<key>characters</key>
+		<string>U</string>
+		<key>keyCode</key>
+		<integer>32</integer>
+		<key>modifierFlags</key>
+		<integer>1179648</integer>
+	</dict>
+	<key>keyEquivalent</key>
+	<string>$@U</string>
+	<key>name</key>
+	<string>UNIX Timestamper</string>
+	<key>output</key>
+	<string>showastexttooltip</string>
+	<key>scope</key>
+	<string>inputfield</string>
+	<key>trigger</key>
+	<string>none</string>
+	<key>uuid</key>
+	<string>11ECB60F-6751-4390-B7D5-D9B7CB6FC81A</string>
+</dict>
+</plist>


### PR DESCRIPTION
Lately I found I needed this more than usual. Maybe it can be of use to someone else who quickly want to know what that 1434357421 is 2015-06-15 08:37:01.