### PR TITLE
Escapes newline character in cell data, fixes multi-line text exports

### DIFF
--- a/core/CopyAsJSON.spBundle/command.plist
+++ b/core/CopyAsJSON.spBundle/command.plist
@@ -54,7 +54,7 @@ while($rowData) {
 
 		# re-escape \t and \n
 		$cellData = $data[$i];
-		$cellData =~ s/↵/\n/g;
+		$cellData =~ s/↵/\\n/g;
 		$cellData =~ s/⇥/\t/g;
 
 		print "\t\t\t\"$header[$i]\": ";

--- a/core/CopyAsJSON.spBundle/command.plist
+++ b/core/CopyAsJSON.spBundle/command.plist
@@ -55,7 +55,7 @@ while($rowData) {
 		# re-escape \t and \n
 		$cellData = $data[$i];
 		$cellData =~ s/↵/\\n/g;
-		$cellData =~ s/⇥/\t/g;
+		$cellData =~ s/⇥/\\t/g;
 
 		print "\t\t\t\"$header[$i]\": ";
 


### PR DESCRIPTION
I noticed that multi-line text data was being output with actual linebreaks, rather than \n, which isn't valid JSON. This fixes that.
