### PR TITLE
Always have trailing pipe characters on Markdown tables.

### DIFF
--- a/contributed/Copy as Markdown.spBundle/command.plist
+++ b/contributed/Copy as Markdown.spBundle/command.plist
@@ -15,8 +15,8 @@ import sys
 
 rows = [line.strip().split('\t') for line in sys.stdin]
 longest = [max(len(v) for v in col) for col in zip(*rows)]
-out_rows = [' | '.join(v.ljust(l) for l, v in zip(longest, row)) for row in rows]
-out_rows.insert(1, '|'.join('-' * (l + 2) for l in longest)[1:])
+out_rows = [' | '.join(v.ljust(l) + ' |' for l, v in zip(longest, row)) for row in rows]
+out_rows.insert(1, '|'.join('-' * (l + 2) for l in longest)[1:] + ' |')
 out_value = '\n'.join(out_rows)
 
 proc = subprocess.Popen(['/usr/bin/pbcopy'], stdin=subprocess.PIPE)


### PR DESCRIPTION
Hi,

This fixes the "Copy as Markdown" bundle to handle a table with 1 column.

Previously a table with 1 column would be copied as

```
count(*)
--------
123     
```

which renders as

count(*)
--------
123     


Now it is copied as

```
count(*) |
--------- |
123      |
```

which renders as

count(*) |
--------- |
123      |


Thanks,

David B