### PR TITLE
Copy as markdown

### DIFF
--- a/contributed/Copy as Markdown.spBundle/command.plist
+++ b/contributed/Copy as Markdown.spBundle/command.plist
@@ -15,8 +15,8 @@ import sys
 
 rows = [line.strip().split('\t') for line in sys.stdin]
 longest = [max(len(v) for v in col) for col in zip(*rows)]
-out_rows = [' | '.join(v.ljust(l) + ' |' for l, v in zip(longest, row)) for row in rows]
-out_rows.insert(1, '|'.join('-' * (l + 2) for l in longest)[1:] + ' |')
+out_rows = [' | '.join(v.ljust(l) for l, v in zip(longest, row)) + ' |' for row in rows]
+out_rows.insert(1, '|'.join('-' * (l + 2) for l in longest)[1:] + '|')
 out_value = '\n'.join(out_rows)
 
 proc = subprocess.Popen(['/usr/bin/pbcopy'], stdin=subprocess.PIPE)

--- a/contributed/Copy as Markdown.spBundle/command.plist
+++ b/contributed/Copy as Markdown.spBundle/command.plist
@@ -9,9 +9,12 @@
 	<key>command</key>
 	<string>#!/usr/bin/python2.7
 
+import os
 import subprocess
 import sys
 
+# Force pasteboard to treat this text as UTF-8 encoded.
+os.environ['LANG'] = 'en_US.UTF-8'
 
 rows = [line.strip().split('\t') for line in sys.stdin]
 longest = [max(len(v) for v in col) for col in zip(*rows)]


### PR DESCRIPTION
Hello,

These changes fix formatting of tables for the copy as markdown bundle, and set the text encoding to UTF-8 when copying data to the pasteboard.

Hmm… maybe it would be better to use the declared encoding of the database table. Is that what SequelPro uses? Anyway, other bundles appear to hard-code UTF-8.

Example:

![screen shot 2016-07-21 at 11 02 40](https://cloud.githubusercontent.com/assets/334087/17019160/eec53444-4f32-11e6-98a5-56234211bd72.png)


When copied results in:

```
id  | fname   | lname        | email               | partnerid |
----|---------|--------------|---------------------|-----------|
983 | Jimmy   | Rähse       | jimmy@example.com   | NULL      |
984 | Tony    | Vogt         | tony@example.com    | NULL      |
985 | Susie   | Großmann    | susie@example.com   | NULL      |
986 | Charlie | König       | charlie@example.com | NULL      |
987 | Randy   | Köhring     | randy@example.com   | 511096    |
988 | Stevie  | Voshage      | stevie@example.com  | NULL      |
989 | Nicky   | Graf Rüssel | nicky@example.com   | 387362    |
```

Which looks like:

id  | fname   | lname        | email               | partnerid |
----|---------|--------------|---------------------|-----------|
983 | Jimmy   | Rähse       | jimmy@example.com   | NULL      |
984 | Tony    | Vogt         | tony@example.com    | NULL      |
985 | Susie   | Großmann    | susie@example.com   | NULL      |
986 | Charlie | König       | charlie@example.com | NULL      |
987 | Randy   | Köhring     | randy@example.com   | 511096    |
988 | Stevie  | Voshage      | stevie@example.com  | NULL      |
989 | Nicky   | Graf Rüssel | nicky@example.com   | 387362    |988 | Peter     | Voshage      | p.voshage@pflegemarkt.com      | NULL      |
