### PR TITLE
Fix URL Encoded Space in Microsoft Excel

### DIFF
--- a/core/Open Selected Table.spBundle/command.plist
+++ b/core/Open Selected Table.spBundle/command.plist
@@ -34,6 +34,11 @@ done
 # Read the chosen list item
 APP=$(cat "$SP_QUERY_RESULT_FILE")
 
+# Fix URL Encoding
+if [ $APP = "Microsoft%20Excel" ]; then
+	APP=$(echo "Microsoft Excel")
+fi
+
 # Check if user dismissed, if so bail (if $APP is empty := user pressed ESC)
 if [ -z "$APP" ]; then
 	rm -f "$SP_QUERY_RESULT_FILE"


### PR DESCRIPTION
I kept getting an error because this is URL encoding `Microsoft Excel` to `Microsoft%20Excel`. This just checks for that a fixes it.
