### PR TITLE
fixed a bug related to not escaping newlines in text fields

### DIFF
--- a/core/CopyAsJSON.spBundle/command.plist
+++ b/core/CopyAsJSON.spBundle/command.plist
@@ -69,9 +69,10 @@ while($rowData) {
 			print "$d";
 		} else {
 			chomp($cellData);
+			$cellData =~ s/(?:\r)?\n/\\n/g;
 			print "\"$cellData\"";
 		}
-		
+
 		# suppress last ,
 		if($i&lt;$h_cnt) {
 			print ",";


### PR DESCRIPTION
Theres currently a bug where if you try to copy a field that has newlines the output will not escape them. This fixes that.